### PR TITLE
Add a copyright header to all files

### DIFF
--- a/antenna.c
+++ b/antenna.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <math.h>
 #include <glib.h>

--- a/antenna.h
+++ b/antenna.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __ANTENNA_H__
 #define __ANTENNA_H__
 

--- a/cassbeam.c
+++ b/cassbeam.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <math.h>
 #include <glib.h>

--- a/constants.h
+++ b/constants.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __CONSTANTS_H__
 #define __CONSTANTS_H__
 

--- a/illum.c
+++ b/illum.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <string.h>
 #include <glib.h>

--- a/illum.h
+++ b/illum.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __ILLUM_H__
 #define __ILLUM_H__
 

--- a/image-vector.c
+++ b/image-vector.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <glib.h>
 #include "image-vector.h"
 

--- a/image-vector.h
+++ b/image-vector.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __IMAGE_VECTOR__
 #define __IMAGE_VECTOR__
 

--- a/image.c
+++ b/image.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <glib.h>
 #include <string.h>
 #include <stdio.h>

--- a/image.h
+++ b/image.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __IMAGE_H__
 #define __IMAGE_H__
 

--- a/intvector.c
+++ b/intvector.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <glib.h>
 #include <stdio.h>
 #include "intvector.h"

--- a/intvector.h
+++ b/intvector.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __INT_VECTOR__
 #define __INT_VECTOR__
 

--- a/keyvalue.c
+++ b/keyvalue.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/keyvalue.h
+++ b/keyvalue.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __KEYVALUE__
 #define __KEYVALUE__
 

--- a/mathfunc.c
+++ b/mathfunc.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <math.h>
 #include "mathfunc.h"
 

--- a/mathfunc.h
+++ b/mathfunc.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __MATHFUNC_H__
 #define __MATHFUNC_H__
 

--- a/polygon.c
+++ b/polygon.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <glib.h>
 #include <math.h>
 #include "polygon.h"

--- a/polygon.h
+++ b/polygon.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __POLYGON_H__
 #define __POLYGON_H__
 

--- a/randdist.c
+++ b/randdist.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <math.h>
 #include <glib.h>
 #include <stdio.h>

--- a/randdist.h
+++ b/randdist.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __GAUSS__
 #define __GAUSS__
 

--- a/vecarray.c
+++ b/vecarray.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <stdarg.h>
 #include <glib.h>
 #include <stdio.h>

--- a/vecarray.h
+++ b/vecarray.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __VECARRAY__
 #define __VECARRAY__
 

--- a/vector-fftw.c
+++ b/vector-fftw.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <glib.h>
 #include "vector-fftw.h"
 

--- a/vector-fftw.h
+++ b/vector-fftw.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __VECTOR_FFTW_H__
 #define __VECTOR_FFTW_H__
 

--- a/vector.c
+++ b/vector.c
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>

--- a/vector.h
+++ b/vector.h
@@ -1,3 +1,19 @@
+/* cassbeam - a Cassegrain antenna simulator
+    Copyright (C) August 18, 2003  Walter Brisken
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <http://www.gnu.org/licenses/>.
 #ifndef __VECTOR__
 #define __VECTOR__
 


### PR DESCRIPTION
This patch is taken from the old cassbeam Debian package. It may help others to keep the copyright if one re-uses one of the files in another project.
