### PR TITLE
Rename executable from casabeam to cassbeam.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -32,7 +32,7 @@ doc: doc/cassbeam.tex
 
 install: $(TARGETS) $(PYPROGS)
 	-rm -f $(DESTDIR)@prefix@/bin/cassbeam
-	install -D -m755 cassbeam $(DESTDIR)@prefix@/bin/casabeam
+	install -D -m755 cassbeam $(DESTDIR)@prefix@/bin/cassbeam
 
 uninstall:
 	-rm -f $(DESTDIR)@prefix@/bin/cassbeam


### PR DESCRIPTION
This seems to be a typo (?)
